### PR TITLE
LESS_OPTIONS config variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,9 @@ Settings
 ``LESS_EXECUTABLE``
     Path to LESS compiler executable. Default: ``"lessc"``.
 
+``LESS_OPTIONS``
+    Options sent to ``lessc``. Default: ``[]``.
+
 ``LESS_ROOT``
     Controls the absolute file path that compiled files will be written to. Default: ``STATIC_ROOT``.
 

--- a/less/settings.py
+++ b/less/settings.py
@@ -7,6 +7,7 @@ LESS_CACHE_TIMEOUT = getattr(settings, "LESS_CACHE_TIMEOUT", 60 * 60 * 24 * 30) 
 LESS_MTIME_DELAY = getattr(settings, "LESS_MTIME_DELAY", 10) # 10 seconds
 LESS_ROOT = getattr(settings, "LESS_ROOT", getattr(settings, "STATIC_ROOT", getattr(settings, "MEDIA_ROOT")))
 LESS_OUTPUT_DIR = getattr(settings, "LESS_OUTPUT_DIR", "LESS_CACHE")
+LESS_OPTIONS = getattr(settings, "LESS_OPTIONS", [])
 LESS_DEVMODE = getattr(settings, "LESS_DEVMODE", False)
 LESS_DEVMODE_WATCH_DIRS = getattr(settings, "LESS_DEVMODE_WATCH_DIRS", [settings.STATIC_ROOT])
 LESS_DEVMODE_EXCLUDE = getattr(settings, "LESS_DEVMODE_EXCLUDE", ())

--- a/less/utils.py
+++ b/less/utils.py
@@ -1,4 +1,5 @@
-from less.settings import LESS_EXECUTABLE, LESS_ROOT, LESS_OUTPUT_DIR
+from less.settings import LESS_EXECUTABLE, LESS_ROOT, LESS_OUTPUT_DIR, \
+        LESS_OPTIONS
 from django.conf import settings
 import logging
 import posixpath
@@ -39,7 +40,8 @@ def compile_less(input, output, less_path):
     if not os.path.exists(less_root):
         os.makedirs(less_root)
 
-    args = [LESS_EXECUTABLE, input]
+    args = [LESS_EXECUTABLE] + LESS_OPTIONS + [input]
+    print args
     popen_kwargs = dict(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/less/utils.py
+++ b/less/utils.py
@@ -41,7 +41,6 @@ def compile_less(input, output, less_path):
         os.makedirs(less_root)
 
     args = [LESS_EXECUTABLE] + LESS_OPTIONS + [input]
-    print args
     popen_kwargs = dict(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
Config variable LESS_OPTIONS provide possibility of send
options to less executable. It is very useful for compressing.

Usage:
LESS_OPTIONS = ['-O2', '-x', '--strict-imports']
