### PR TITLE
Solves #20 when checking cache time

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Settings
     Controls the directory inside ``LESS_ROOT`` that compiled files will be written to. Default: ``"LESS_CACHE"``.
 
 ``LESS_USE_CACHE``
-    Whether to use cache for inline styles. Default: ``True``.
+    Whether to use cache for styles. Default: ``True``. You can set ``LESS_USE_CACHE = not DEBUG`` in your settings, so the less code will be compiled every load just in development process.
 
 ``LESS_CACHE_TIMEOUT``
     Cache timeout for inline styles (in seconds). Default: 30 days.

--- a/less/cache.py
+++ b/less/cache.py
@@ -35,7 +35,8 @@ def get_mtime(filename):
 def get_hashed_mtime(filename, length=12):
     try:
         filename = os.path.realpath(filename)
-        mtime = str(int(get_mtime(filename)))
+        dirname = os.path.dirname(filename)
+        mtime = str(int(get_mtime(dirname)))
     except OSError:
         return None
     return get_hexdigest(mtime, length)

--- a/less/templatetags/less.py
+++ b/less/templatetags/less.py
@@ -112,7 +112,7 @@ def less(path):
         filesystem_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
         encoded_full_path = full_path.encode(filesystem_encoding)
 
-    if not os.path.exists(output_path):
+    if not os.path.exists(output_path) or not LESS_USE_CACHE:
         compile_less(encoded_full_path, output_path, path)
 
         # Remove old files


### PR DESCRIPTION
Checks the directory modification time instead of a single file. This way, if you modify a file imported in your primary less file, the css is regenerated.

**Edit**: I have also added a commit, it makes if you have setted `LESS_USE_CACHE = False`, the less code is compiled every request.
