### PR TITLE
Allow chars that are not ascii-encodable in the inline-less template tag

### DIFF
--- a/less/templatetags/less.py
+++ b/less/templatetags/less.py
@@ -30,7 +30,7 @@ class InlineLessNode(Node):
 
     def compile(self, source):
         source_file = NamedTemporaryFile(delete=False)
-        source_file.write(source)
+        source_file.write(source.encode('utf-8'))
         source_file.close()
         args = [LESS_EXECUTABLE, source_file.name]
 

--- a/less/templatetags/less.py
+++ b/less/templatetags/less.py
@@ -30,7 +30,7 @@ class InlineLessNode(Node):
 
     def compile(self, source):
         source_file = NamedTemporaryFile(delete=False)
-        source_file.write(source.encode('utf-8'))
+        source_file.write(source.encode(settings.FILE_CHARSET))
         source_file.close()
         args = [LESS_EXECUTABLE, source_file.name]
 


### PR DESCRIPTION
I did this because I was getting an error with bootstrap 3 as the input:

ERROR Internal Server Error: /app/9/uiestate.css
Traceback (most recent call last):
  File "/Users/kssworld93/Projects/appcubator/appcubator-site/venv/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, _callback_args, *_callback_kwargs)
  File "/Users/kssworld93/Projects/appcubator/appcubator-site/venv/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 77, in wrapped_view
    return view_func(_args, *_kwargs)
  File "/Users/kssworld93/Projects/appcubator/appcubator-site/appcubator/views/app.py", line 593, in css_sheet
    css_string = t.render(context)
  File "/Users/kssworld93/Projects/appcubator/appcubator-site/venv/lib/python2.7/site-packages/django/template/base.py", line 140, in render
    return self._render(context)
  File "/Users/kssworld93/Projects/appcubator/appcubator-site/venv/lib/python2.7/site-packages/django/template/base.py", line 134, in _render
    return self.nodelist.render(context)
  File "/Users/kssworld93/Projects/appcubator/appcubator-site/venv/lib/python2.7/site-packages/django/template/base.py", line 823, in render
    bit = self.render_node(node, context)
  File "/Users/kssworld93/Projects/appcubator/appcubator-site/venv/lib/python2.7/site-packages/django/template/debug.py", line 74, in render_node
    return node.render(context)
  File "/Users/kssworld93/Projects/appcubator/appcubator-site/venv/lib/python2.7/site-packages/less/templatetags/less.py", line 62, in render
    output = self.compile(output)
  File "/Users/kssworld93/Projects/appcubator/appcubator-site/venv/lib/python2.7/site-packages/less/templatetags/less.py", line 33, in compile
    source_file.write(source)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 131333-131334: ordinal not in range(128)

Now it works fine for me. What do I need to do to get this fix pulled in?
